### PR TITLE
Log version on startup

### DIFF
--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -1,4 +1,6 @@
+import logging
 import os
+from importlib.metadata import PackageNotFoundError, version
 
 from pulsar import Client, ConsumerDeadLetterPolicy, ConsumerType
 
@@ -27,6 +29,14 @@ def run(messagers: dict[str, CatalogueChangeMessager], subscription_name: str):
         "annotations-ingester",
     )
     """
+
+    try:
+        __version__ = version("eodhp_utils")
+        logging.info(f"eodhp-utils runner starting, version {__version__}")
+    except PackageNotFoundError:
+        # Not installed as a package, eg running directly from Git clone.
+        logging.info("eodhp_utils runner starting from dev environment")
+        pass
 
     topics = list(messagers.keys())
 

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -36,7 +36,6 @@ def run(messagers: dict[str, CatalogueChangeMessager], subscription_name: str):
     except PackageNotFoundError:
         # Not installed as a package, eg running directly from Git clone.
         logging.info("eodhp_utils runner starting from dev environment")
-        pass
 
     topics = list(messagers.keys())
 


### PR DESCRIPTION
This logs the version number auto-generated by setuptools-git-versioning during startup. This might be `0.1.3` if the code matches a Git tag, or `0.1.3.post3+git.823594e6.dirty` if it's 3 commits after a tag and has uncommitted changes.
