### PR TITLE
Centralize some more aspects of harvest messaging in eodhp-utils

### DIFF
--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -12,7 +12,7 @@ from eodhp_utils.messagers import CatalogueChangeMessager
 pulsar_client = None
 aws_client = None
 DEBUG_TOPIC = "eodhp-utils-debugging"
-SUSPEND_TIME = 5000
+SUSPEND_TIME = 5
 
 
 def get_pulsar_client(pulsar_url=None):

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -169,7 +169,7 @@ def run(
                 logging.debug("Sending takeover message")
                 takeover_producer.send(bytes(takeover_msg, "utf-8"))
                 suspended_until = now + SUSPEND_TIME / 2
-            else:
+            elif suspended_until != 0:
                 # Suspension has expired.
                 logging.warning("Takeover expired, resuming message reception")
                 consumer.resume_message_listener()

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -175,7 +175,6 @@ def run(
                 suspended_until = now + suspension_remaining
         else:
             # Check for takeover messages.
-            # Note:
             try:
                 takeover_consumer.seek(int((now - SUSPEND_TIME) * 1000))
 
@@ -205,7 +204,9 @@ def run(
 
         try:
             pulsar_message = consumer.receive(
-                int(suspension_remaining * 1000) if suspension_remaining > 0 else None
+                int(suspension_remaining * 1000)
+                if suspension_remaining > 0
+                else int(SUSPEND_TIME * 1000)
             )
         except Timeout:
             continue

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -205,7 +205,7 @@ def run(
 
         try:
             pulsar_message = consumer.receive(
-                suspension_remaining * 1000 if suspension_remaining > 0 else None
+                int(suspension_remaining * 1000) if suspension_remaining > 0 else None
             )
         except Timeout:
             continue

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -39,6 +39,36 @@ def get_boto3_session():
     return aws_client
 
 
+LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
+
+
+def setup_logging(verbosity=0):
+    if verbosity == 0:
+        logging.getLogger("botocore").setLevel(logging.CRITICAL)
+        logging.getLogger("boto3").setLevel(logging.CRITICAL)
+        logging.getLogger("urllib3").setLevel(logging.CRITICAL)
+
+        logging.basicConfig(level=logging.WARNING, format=LOG_FORMAT)
+    elif verbosity == 1:
+        logging.getLogger("botocore").setLevel(logging.ERROR)
+        logging.getLogger("boto3").setLevel(logging.ERROR)
+        logging.getLogger("urllib3").setLevel(logging.ERROR)
+
+        logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
+    elif verbosity == 2:
+        logging.getLogger("botocore").setLevel(logging.WARNING)
+        logging.getLogger("boto3").setLevel(logging.WARNING)
+        logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+        logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
+    elif verbosity > 2:
+        logging.getLogger("botocore").setLevel(logging.DEBUG)
+        logging.getLogger("boto3").setLevel(logging.DEBUG)
+        logging.getLogger("urllib3").setLevel(logging.DEBUG)
+
+        logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
+
+
 def run(
     messagers: dict[str, CatalogueChangeMessager],
     subscription_name: str,

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -166,10 +166,12 @@ def run(
         if suspension_remaining <= 0:
             if takeover_mode:
                 # Confirm our takeover
+                logging.debug("Sending takeover message")
                 takeover_producer.send(bytes(takeover_msg, "utf-8"))
                 suspended_until = now + SUSPEND_TIME / 2
             else:
                 # Suspension has expired.
+                logging.warning("Takeover expired, resuming message reception")
                 consumer.resume_message_listener()
 
         try:
@@ -184,6 +186,7 @@ def run(
         if topic_name == DEBUG_TOPIC:
             data_dict = json.loads(pulsar_message.data().decode("utf-8"))
             if data_dict.get("suspend_subscription") == subscription_name:
+                logging.warning("Takeover active, pausing message reception")
                 consumer.pause_message_listener()
                 suspended_until = max(
                     suspended_until, pulsar_message.publish_timestamp / 1000.0 + SUSPEND_TIME

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -5,7 +5,7 @@ import time
 from importlib.metadata import PackageNotFoundError, version
 
 import boto3.session
-from pulsar import Client, ConsumerDeadLetterPolicy, ConsumerType
+from pulsar import Client, ConsumerDeadLetterPolicy, ConsumerType, Timeout
 
 from eodhp_utils.messagers import CatalogueChangeMessager
 
@@ -189,7 +189,7 @@ def run(
                             suspended_until,
                             pulsar_message.publish_timestamp / 1000.0 + SUSPEND_TIME,
                         )
-            except TimeoutError:
+            except Timeout:
                 pass
 
             # Wait for takeover expiry
@@ -207,7 +207,7 @@ def run(
             pulsar_message = consumer.receive(
                 suspension_remaining * 1000 if suspension_remaining > 0 else None
             )
-        except TimeoutError:
+        except Timeout:
             continue
 
         topic_name = pulsar_message.topic_name().split("/")[-1]

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -91,6 +91,7 @@ def run(
     subscription_name: str,
     takeover_mode=False,
     msg_limit=None,
+    pulsar_url=None,
 ):
     """Run loop to monitor arrival of pulsar messages on a given topic.
 
@@ -134,7 +135,7 @@ def run(
     max_redelivery_count = 3
     delay_ms = 30000
 
-    client = get_pulsar_client()
+    client = get_pulsar_client(pulsar_url=pulsar_url)
 
     consumer = client.subscribe(
         topic=topics,

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -115,7 +115,8 @@ def run(
         takeover_msg = json.dumps({"suspend_subscription": subscription_name})
 
     while msg_limit is None or msg_limit > 0:
-        msg_limit -= 1
+        if msg_limit is not None:
+            msg_limit -= 1
 
         now = time.time()
         suspension_remaining = suspended_until - now

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -177,7 +177,7 @@ def run(
             # Check for takeover messages.
             # Note:
             try:
-                takeover_consumer.seek(now - SUSPEND_TIME)
+                takeover_consumer.seek(int((now - SUSPEND_TIME) * 1000))
 
                 while True:
                     pulsar_message = takeover_consumer.receive(0)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -166,4 +166,4 @@ def test_takeover_results_in_pause():
 
         mock_messager.consume.assert_called_once_with(mock_message)
         mock_consumer.pause_message_listener.assert_has_calls([mock.call()] * 4)
-        mock_consumer.resume_message_listener.assert_has_calls([mock.call()] * 4)
+        mock_consumer.resume_message_listener.assert_has_calls([mock.call()] * 3)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -157,17 +157,19 @@ def test_takeover_results_in_pause():
         mock_takeover_message = mock.MagicMock(name="takeover-message")
         mock_takeover_message.topic_name.return_value = f"x/{eodhp_utils.runner.DEBUG_TOPIC}"
         mock_takeover_message.data.return_value = b'{"suspend_subscription": "test-subscription"}'
-        mock_takeover_message.publish_timestamp = 1000
+        mock_takeover_message.publish_timestamp.return_value = 1000
 
         # We mock the following five steps:
-        #  - Time 50: two takeover messages received, sleep until 5001, real message
+        #  - Time 50: two takeover messages received, sleep until 6001
+        #  - Time 6010: no takeover messages, real message
         #  - Time 7700: takeover message received, no sleep because message too old, real message received
         #
         # Note: logger calls time.time()
-        mock_time.time.side_effect = [0.050, 7.7]
+        mock_time.time.side_effect = [0.050, 6.01, 7.7]
         mock_consumer.receive.side_effect = [
             mock_takeover_message,
             mock_takeover_message,
+            pulsar.Timeout(),
             pulsar.Timeout(),
             mock_message,
             mock_takeover_message,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,34 @@
+import os
+from argparse import Action
+from typing import Sequence
+from unittest import mock
+
+from eodhp_utils import runner
+from eodhp_utils.messagers import Messager
+
+
+class MessagerTester(Messager[str]):
+    messages_received = []
+
+    def process_msg(self, msg: str) -> Sequence[Action]:
+        self.messages_received.append(msg)
+
+        if msg == "EXIT":
+            raise KeyboardInterrupt()
+
+        return []
+
+    def gen_empty_catalogue_message(self, msg: str) -> dict:
+        return {}
+
+
+def test_s3_session_uses_supplied_key():
+    runner.aws_client = None
+
+    with mock.patch.dict(
+        os.environ, {"AWS_ACCESS_KEY": "ACCESSKEY", "AWS_SECRET_ACCESS_KEY": "SECKEY"}
+    ):
+        sess = runner.get_boto3_session()
+
+        assert sess.get_credentials().secret_key == "SECKEY"
+        assert sess.get_credentials().access_key == "ACCESSKEY"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,6 +3,7 @@ from argparse import Action
 from typing import Sequence
 from unittest import mock
 
+import eodhp_utils
 from eodhp_utils import runner
 from eodhp_utils.messagers import Messager
 
@@ -32,3 +33,114 @@ def test_s3_session_uses_supplied_key():
 
         assert sess.get_credentials().secret_key == "SECKEY"
         assert sess.get_credentials().access_key == "ACCESSKEY"
+
+
+def test_messagers_given_messages():
+    with mock.patch("eodhp_utils.runner.get_pulsar_client") as mock_getclient:
+        mock_consumer = mock.MagicMock(name="consumer")
+        mock_getclient().subscribe.return_value = mock_consumer
+
+        # Mock a messager that returns no error.
+        mock_messager = mock.MagicMock(name="messager")
+        mock_messager.consume.return_value.any_temporary.return_value = False
+
+        # Mock reception of a message from a test-topic.
+        mock_message = mock_consumer.receive(None)
+        mock_message.topic_name.return_value = "x/test-topic"
+
+        runner.run({"test-topic": mock_messager}, "test-subscription", msg_limit=1)
+
+        mock_messager.consume.assert_called_once_with(mock_message)
+        mock_consumer.acknowledge.assert_called_once_with(mock_message)
+
+
+def test_takeover_sends_takeover_messages():
+    # Tests that, in takover mode, we send a takeover message every 2.5S.
+    with (
+        mock.patch("eodhp_utils.runner.get_pulsar_client") as mock_getclient,
+        mock.patch("eodhp_utils.runner.time.time") as mock_time,
+    ):
+        mock_consumer = mock.MagicMock(name="consumer")
+        mock_getclient().subscribe.return_value = mock_consumer
+
+        # Mock reception of a message from a test-topic.
+        mock_messager = mock.MagicMock(name="messager")
+        mock_message = mock.MagicMock(name="message")
+        mock_message.topic_name.return_value = "x/test-topic"
+
+        # We mock the following five steps:
+        #  - Time 50: takeover message sent, no message received
+        #  - Time 2600: takeover message sent, no message received
+        #  - Time 5100: takeover message sent, no message received
+        #  - Time 6000: no takeover message sent, message received
+        #  - Time 7600: takeover message sent, no message received
+        mock_time.side_effect = [50, 2600, 5150, 6000, 7700]
+        mock_consumer.receive.side_effect = [
+            TimeoutError(),
+            TimeoutError(),
+            TimeoutError(),
+            mock_message,
+            TimeoutError(),
+        ]
+
+        runner.run(
+            {"test-topic": mock_messager}, "test-subscription", takeover_mode=True, msg_limit=5
+        )
+
+        mock_getclient().create_producer(
+            topic=eodhp_utils.runner.DEBUG_TOPIC, producer_name=any
+        ).send.assert_has_calls(
+            [
+                mock.call(b'{"suspend_subscription": "test-subscription"}'),
+                mock.call(b'{"suspend_subscription": "test-subscription"}'),
+                mock.call(b'{"suspend_subscription": "test-subscription"}'),
+                mock.call(b'{"suspend_subscription": "test-subscription"}'),
+            ]
+        )
+
+        mock_messager.consume.assert_called_once_with(mock_message)
+
+        mock_consumer.pause_message_listener.assert_not_called()
+        mock_consumer.resume_message_listener.assert_not_called()
+
+
+def test_takeover_results_in_pause():
+    # Tests that, when a takeover happens, other consumers pause message reception.
+    with (
+        mock.patch("eodhp_utils.runner.get_pulsar_client") as mock_getclient,
+        mock.patch("eodhp_utils.runner.time.time") as mock_time,
+    ):
+        mock_consumer = mock.MagicMock(name="consumer")
+        mock_getclient().subscribe.return_value = mock_consumer
+
+        # Mock reception of a message from a test-topic.
+        mock_messager = mock.MagicMock(name="messager")
+
+        mock_message = mock.MagicMock(name="message")
+        mock_message.topic_name.return_value = "x/test-topic"
+
+        mock_takeover_message = mock.MagicMock(name="message")
+        mock_takeover_message.topic_name.return_value = f"x/{eodhp_utils.runner.DEBUG_TOPIC}"
+        mock_takeover_message.data.return_value = b'{"suspend_subscription": "test-subscription"}'
+        mock_takeover_message.publish_timestamp = -5000
+
+        # We mock the following five steps:
+        #  - Time 50: takeover message received
+        #  - Time 2600: takeover message received
+        #  - Time 5100: takeover message received
+        #  - Time 6000: ordinary message received
+        #  - Time 7600: takeover message received
+        mock_time.side_effect = [50, 2600, 5150, 6000, 7700]
+        mock_consumer.receive.side_effect = [
+            mock_takeover_message,
+            mock_takeover_message,
+            mock_takeover_message,
+            mock_message,
+            mock_takeover_message,
+        ]
+
+        runner.run({"test-topic": mock_messager}, "test-subscription", msg_limit=5)
+
+        mock_messager.consume.assert_called_once_with(mock_message)
+        mock_consumer.pause_message_listener.assert_has_calls([mock.call()] * 4)
+        mock_consumer.resume_message_listener.assert_has_calls([mock.call()] * 4)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -4,6 +4,7 @@ from typing import Sequence
 from unittest import mock
 
 import eodhp_utils
+import eodhp_utils.runner
 from eodhp_utils import runner
 from eodhp_utils.messagers import Messager
 
@@ -59,6 +60,21 @@ def test_setup_logging_doesnt_error():
     eodhp_utils.runner.setup_logging(1)
     eodhp_utils.runner.setup_logging(2)
     eodhp_utils.runner.setup_logging(3)
+
+
+def test_pulsar_client_uses_arg_over_env_when_set():
+    with (
+        mock.patch("eodhp_utils.runner.Client") as pulsar_client,
+        mock.patch.dict(os.environ, {"PULSAR_URL": "pulsar://example.com/2"}),
+    ):
+        eodhp_utils.runner.get_pulsar_client("pulsar://example.com/1")
+
+        eodhp_utils.runner.pulsar_client = None
+        eodhp_utils.runner.get_pulsar_client()
+
+        pulsar_client.assert_has_calls(
+            (mock.call("pulsar://example.com/1"), mock.call("pulsar://example.com/2"))
+        )
 
 
 def test_takeover_sends_takeover_messages():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -131,7 +131,7 @@ def test_takeover_results_in_pause():
     # Tests that, when a takeover happens, other consumers pause message reception.
     with (
         mock.patch("eodhp_utils.runner.get_pulsar_client") as mock_getclient,
-        mock.patch("eodhp_utils.runner.time.time") as mock_time,
+        mock.patch("eodhp_utils.runner.time") as mock_time,
     ):
         mock_consumer = mock.MagicMock(name="consumer")
         mock_getclient().subscribe.return_value = mock_consumer
@@ -153,7 +153,7 @@ def test_takeover_results_in_pause():
         #  - Time 5100: takeover message received
         #  - Time 6000: ordinary message received
         #  - Time 7600: takeover message received
-        mock_time.side_effect = [50, 2600, 5150, 6000, 7700]
+        mock_time.time.side_effect = [50, 2600, 5150, 6000, 7700]
         mock_consumer.receive.side_effect = [
             mock_takeover_message,
             mock_takeover_message,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -54,6 +54,13 @@ def test_messagers_given_messages():
         mock_consumer.acknowledge.assert_called_once_with(mock_message)
 
 
+def test_setup_logging_doesnt_error():
+    eodhp_utils.runner.setup_logging(0)
+    eodhp_utils.runner.setup_logging(1)
+    eodhp_utils.runner.setup_logging(2)
+    eodhp_utils.runner.setup_logging(3)
+
+
 def test_takeover_sends_takeover_messages():
     # Tests that, in takover mode, we send a takeover message every 2.5S.
     with (

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -51,7 +51,7 @@ def test_messagers_given_messages():
         mock_message = mock.MagicMock(name="message")
 
         def receive_mock(timeout):
-            if timeout is None:
+            if timeout == eodhp_utils.runner.SUSPEND_TIME * 1000:
                 return mock_message
 
             # Takeover reception


### PR DESCRIPTION
This makes several changes to move code and behaviour into eodhp-utils, and to try to make local testing easier.

`get_boto3_session` in eodhp-utils can be used by components to get an authenticated Boto session.

`setup_logging` can be used by components to set up logging in a uniform way across the harvest pipeline, and to support `-v`, `-vv`, etc, options.

`log_component_version` can be used during startup to log a component's version - providing it is using setuptools-git-versioning

`get_pulsar_client` can use an argument to override the PULSAR_URL environment variable. This allows components to let users set this with a CLI parameter.

The biggest change is that `run` now supports 'takeover mode'. Runners with takeover mode off will listen for messages on a special topic and, upon receiving one, will stop processing messages for 5 seconds. Runners with takeover mode on will send such messages every 2.5 seconds. The intent is that a developer can run the component locally in takeover mode (with the Pulsar port forwarded to the cluster) and it will take over processing messages from the deployed version.
