### PR TITLE
Bugfix/retry s3 actions if key not yet present

### DIFF
--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -482,7 +482,7 @@ class CatalogueChangeBodyMessager(CatalogueChangeMessager):
             if e.response["Error"]["Code"] == "NoSuchKey" and retries < 3:
                 logging.warning("Key was not present, trying again")
                 retries += 1
-                self.process_update(input_bucket, input_key, cat_path, source, target, retries)
+                return self.process_update(input_bucket, input_key, cat_path, source, target, retries)
             else:
                 raise
         entry_body = get_result["Body"].read()

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -482,7 +482,9 @@ class CatalogueChangeBodyMessager(CatalogueChangeMessager):
             if e.response["Error"]["Code"] == "NoSuchKey" and retries < 3:
                 logging.warning("Key was not present, trying again")
                 retries += 1
-                return self.process_update(input_bucket, input_key, cat_path, source, target, retries)
+                return self.process_update(
+                    input_bucket, input_key, cat_path, source, target, retries
+                )
             else:
                 raise
         entry_body = get_result["Body"].read()

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -467,9 +467,24 @@ class CatalogueChangeBodyMessager(CatalogueChangeMessager):
     """
 
     def process_update(
-        self, input_bucket: str, input_key: str, cat_path: str, source: str, target: str
+        self,
+        input_bucket: str,
+        input_key: str,
+        cat_path: str,
+        source: str,
+        target: str,
+        retries: int = 0,
     ) -> Sequence[Messager.Action]:
-        get_result = self.s3_client.get_object(Bucket=input_bucket, Key=input_key)
+        try:
+            get_result = self.s3_client.get_object(Bucket=input_bucket, Key=input_key)
+        except botocore.exceptions.ClientError as e:
+            # On some occasions we have seen Pulsar messages arrive before the file is in S3.
+            if e.response["Error"]["Code"] == "NoSuchKey" and retries < 3:
+                logging.warning("Key was not present, trying again")
+                retries += 1
+                self.process_update(input_bucket, input_key, cat_path, source, target, retries)
+            else:
+                raise
         entry_body = get_result["Body"].read()
 
         # Transformer needs updating to ensure that content type is set to this


### PR DESCRIPTION
## Quick Bugfix to address missing Key Error
- Sometimes the Pulsar message is handled before S3 has fully uploaded the file (often when processing workflow outputs)
- If the key is not present, attempt 3 more times to see if this is a latency issue
- Otherwise fail as before