### PR TITLE
Eodhp 830 fixing invalid links for resource catalogue transformer

### DIFF
--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -348,7 +348,7 @@ class Messager[MSGTYPE](ABC):
         # (injected by a previous component like the harvester), those are captured.
         # If not, ctx will be empty (or default), and the new span becomes a root span.
         # Extract properties from message (if any)
-        logging.info(f"pulsar mesg : {msg}")
+        print(f"pulsar mesg : {msg}")
         carrier = msg.properties() if callable(msg.properties) else msg.properties or {}
         # Extract OpenTelemetry context
         ctx = extract(carrier)

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import logging
+import time
 from abc import ABC, abstractmethod
 from typing import Sequence, Union
 
@@ -361,7 +362,7 @@ class Messager[MSGTYPE](ABC):
         failures = Messager.Failures()
 
         # Start Timing for Metrics
-        start_time = trace.time_ns()
+        start_time = time.time_ns()
 
         # Extract the trace context from the incoming message's properties.
         # check with alex what needs to be done here? What key to refer here?
@@ -452,7 +453,7 @@ class Messager[MSGTYPE](ABC):
                 failures.permanent = True
                 msg_failure_counter.add(1, {"status": "permanent_failure"})
 
-        elapsed_time = (trace.time_ns() - start_time) / 1e6  # Convert ns to ms
+        elapsed_time = (time.time_ns() - start_time) / 1e6  # Convert ns to ms
         msg_processing_time.record(elapsed_time, {"topic": msg.topic_name()})
 
         return failures

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -365,7 +365,7 @@ class Messager[MSGTYPE](ABC):
             # Attach relevant metadata to the span
             span.set_attribute("message_id", msg.message_id())
             span.set_attribute("topic", msg.topic_name())
-            span.set_attribute("pulsar_subscription", self.subscription_name)
+            # span.set_attribute("pulsar_subscription", self.subscription_name)
 
             # Log message processing start
             span.add_event("Message processing started")

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -348,6 +348,7 @@ class Messager[MSGTYPE](ABC):
         # (injected by a previous component like the harvester), those are captured.
         # If not, ctx will be empty (or default), and the new span becomes a root span.
         # Extract properties from message (if any)
+        logging.info(f"pulsar mesg : {msg}")
         carrier = msg.properties() if callable(msg.properties) else msg.properties or {}
         # Extract OpenTelemetry context
         ctx = extract(carrier)

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -371,9 +371,12 @@ class Messager[MSGTYPE](ABC):
             "messager.consume", context=ctx, kind=SpanKind.CONSUMER
         ) as span:
             # Attach relevant metadata to the span
-            span.set_attribute("message_id", msg.message_id())
+            span.set_attribute("message_id", str(msg.message_id()))
             span.set_attribute("topic", msg.topic_name())
-            # span.set_attribute("pulsar_subscription", self.subscription_name)
+            span.set_attribute("workspace", data_dict.get("workspace", "unknown"))
+            span.set_attribute("added_keys", str(data_dict.get("added_keys", [])))
+            span.set_attribute("updated_keys", str(data_dict.get("updated_keys", [])))
+            span.set_attribute("deleted_keys", str(data_dict.get("deleted_keys", [])))
 
             # Log message processing start
             span.add_event("Message processing started")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
     "botocore",
     "boto3",
     "pulsar-client",
+    "opentelemetry-distro"
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ dependencies = [
     "botocore",
     "boto3",
     "pulsar-client",
-    "opentelemetry-distro"
+    "opentelemetry-distro",
+    "opentelemetry-exporter-otlp-proto-grpc"
 ]
 
 # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
This is a proposal PR. Could you please guide me on the right steps to follow from here?

So My idea is

I would check if a span has already been created. If it has, I will ensure that the span properties are properly captured and then establish a relationship with the next span. This way, the context is correctly propagated across the system.

The idea is to extract the trace context from the incoming message’s properties. 
I have assumed that there will a be a property key associated in pulsar message which already have the tracing properties inside it. But this is just an assumption as I am not sure where would first trace would come from.

If the message has trace-related properties, they will be captured. If they are not present, I will assume the context is empty and create a new span, which will become the root span. This span will follow along the entire journey.

I have also added metrics to record success and error logs.

I don’t think the consume method will log any errors if any links fail to process. It will only record that the Pulsar message was received and sent for processing. I believe I need to add spans in a few more places, such as the run method in runner.py, and possibly in transformer, link_processor, etc.

Please suggest me if you have something in your mind @ahaywardtvuk 

I have also modified the docker file to include the environment variables to run the transformer.

# Set environment variables for OpenTelemetry
ENV OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
ENV OTEL_SERVICE_NAME=harvest-transformer

ENTRYPOINT ["opentelemetry-instrument", "--traces_exporter", "console", "python", "-m", "harvest_transformer"]
