### PR TITLE
otel in eodhp-utils

### DIFF
--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -374,7 +374,7 @@ class Messager[MSGTYPE](ABC):
                 # Send Pulsar message with trace context
                 self.producer.send(data, properties=properties)
 
-                logging.debug("Catalogue change message sent to Pulsar")
+                logging.debug(f"Catalogue change message sent to Pulsar : {properties}")
         except TemporaryFailure:
             logging.exception("Temporary failure processing message %s", msg)
             failures.temporary = True

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -354,7 +354,7 @@ class Messager[MSGTYPE](ABC):
         sensible. This means it doesn't throw exceptions.
         """
         current_baggage = get_all()
-        logging.info(f"Consume method: current baggage: {current_baggage}")
+        logging.error(f"Consume method: current baggage: {current_baggage}")
         failures = Messager.Failures()
 
         try:
@@ -377,7 +377,7 @@ class Messager[MSGTYPE](ABC):
                 # ✅ Send Pulsar message with trace context
                 self.producer.send(data, properties=properties)
 
-                logging.debug("Catalogue change message sent to Pulsar")
+                logging.error("Catalogue change message sent to Pulsar")
         except TemporaryFailure:
             logging.exception("Temporary failure processing message %s", msg)
             failures.temporary = True

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -341,7 +341,10 @@ class Messager[MSGTYPE](ABC):
         else:
             raise AssertionError(f"BUG: Saw unknown action type {action}")
 
-    def consume(self, msg: MSGTYPE, properties=None) -> Failures:
+    def consume(
+        self,
+        msg: MSGTYPE,
+    ) -> Failures:
         """
         This consumes an input, asks the Messager (via an implementation in a task-specific
         subclass) to process it, then runs the set of actions requested by that processing.
@@ -365,8 +368,7 @@ class Messager[MSGTYPE](ABC):
                 data = json.dumps(change_message).encode("utf-8")
 
                 # Inject OpenTelemetry trace context into message properties
-                if properties is None:
-                    properties = {}
+                properties = {}
                 inject(properties)
 
                 # ✅ Send Pulsar message with trace context

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -10,7 +10,6 @@ import botocore.exceptions
 import pulsar
 import pulsar.exceptions
 from opentelemetry.baggage import get_all
-from opentelemetry.propagate import inject
 from pulsar import Message
 from pulsar.schema import BytesSchema, JsonSchema, Record, Schema
 
@@ -371,11 +370,11 @@ class Messager[MSGTYPE](ABC):
                 data = json.dumps(change_message).encode("utf-8")
 
                 # Inject OpenTelemetry trace context into message properties
-                properties = {}
-                inject(properties)
+                # properties = {}
+                # inject(properties)
 
                 # Send Pulsar message with trace context
-                self.producer.send(data, properties=properties)
+                self.producer.send(data)
 
                 logging.error("Catalogue change message sent to Pulsar")
         except TemporaryFailure:

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -10,6 +10,7 @@ import botocore.exceptions
 import pulsar
 import pulsar.exceptions
 from opentelemetry.baggage import get_all
+from opentelemetry.propagate import inject
 from pulsar import Message
 from pulsar.schema import BytesSchema, JsonSchema, Record, Schema
 
@@ -370,11 +371,11 @@ class Messager[MSGTYPE](ABC):
                 data = json.dumps(change_message).encode("utf-8")
 
                 # Inject OpenTelemetry trace context into message properties
-                # properties = {}
-                # inject(properties)
+                properties = {}
+                inject(properties)
 
                 # Send Pulsar message with trace context
-                self.producer.send(data)
+                self.producer.send(data, properties=properties)
 
                 logging.error("Catalogue change message sent to Pulsar")
         except TemporaryFailure:

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -29,7 +29,7 @@ class TemporaryFailure(Exception):
 
 
 def _is_boto_error_temporary(
-    exc: Union[botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError]
+    exc: Union[botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError],
 ) -> bool:
     temp_excepts = (
         botocore.exceptions.ConnectionError,
@@ -340,7 +340,7 @@ class Messager[MSGTYPE](ABC):
         else:
             raise AssertionError(f"BUG: Saw unknown action type {action}")
 
-    def consume(self, msg: MSGTYPE) -> Failures:
+    def consume(self, msg: MSGTYPE, properties=None) -> Failures:
         """
         This consumes an input, asks the Messager (via an implementation in a task-specific
         subclass) to process it, then runs the set of actions requested by that processing.
@@ -362,7 +362,7 @@ class Messager[MSGTYPE](ABC):
                 # change message.
                 change_message = self.gen_catalogue_message(msg, cat_changes)
                 data = json.dumps(change_message).encode("utf-8")
-                self.producer.send(data)
+                self.producer.send(data, properties=properties)
 
                 logging.debug("Catalogue change message sent to Pulsar")
         except TemporaryFailure:

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -9,7 +9,6 @@ import botocore
 import botocore.exceptions
 import pulsar
 import pulsar.exceptions
-from opentelemetry.baggage import get_all
 from opentelemetry.propagate import inject
 from pulsar import Message
 from pulsar.schema import BytesSchema, JsonSchema, Record, Schema
@@ -353,8 +352,6 @@ class Messager[MSGTYPE](ABC):
         This returns an object specified any failures that occurred and whether retrying is
         sensible. This means it doesn't throw exceptions.
         """
-        current_baggage = get_all()
-        logging.error(f"Consume method from messagers class: current baggage: {current_baggage}")
         failures = Messager.Failures()
 
         try:

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -9,6 +9,7 @@ import botocore
 import botocore.exceptions
 import pulsar
 import pulsar.exceptions
+from opentelemetry.baggage import get_all
 from opentelemetry.propagate import inject
 from pulsar import Message
 from pulsar.schema import BytesSchema, JsonSchema, Record, Schema
@@ -352,6 +353,8 @@ class Messager[MSGTYPE](ABC):
         This returns an object specified any failures that occurred and whether retrying is
         sensible. This means it doesn't throw exceptions.
         """
+        current_baggage = get_all()
+        logging.info(f"Consume method: current baggage: {current_baggage}")
         failures = Messager.Failures()
 
         try:

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -374,7 +374,7 @@ class Messager[MSGTYPE](ABC):
                 # Send Pulsar message with trace context
                 self.producer.send(data, properties=properties)
 
-                logging.error("Catalogue change message sent to Pulsar")
+                logging.debug("Catalogue change message sent to Pulsar")
         except TemporaryFailure:
             logging.exception("Temporary failure processing message %s", msg)
             failures.temporary = True

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -354,7 +354,7 @@ class Messager[MSGTYPE](ABC):
         sensible. This means it doesn't throw exceptions.
         """
         current_baggage = get_all()
-        logging.error(f"Consume method: current baggage: {current_baggage}")
+        logging.error(f"Consume method from messagers class: current baggage: {current_baggage}")
         failures = Messager.Failures()
 
         try:
@@ -374,7 +374,7 @@ class Messager[MSGTYPE](ABC):
                 properties = {}
                 inject(properties)
 
-                # ✅ Send Pulsar message with trace context
+                # Send Pulsar message with trace context
                 self.producer.send(data, properties=properties)
 
                 logging.error("Catalogue change message sent to Pulsar")

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -11,7 +11,7 @@ from opentelemetry.baggage import get_all
 from opentelemetry.processor.baggage import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
 from opentelemetry.propagate import extract
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 from pulsar import Client, Consumer, ConsumerDeadLetterPolicy, ConsumerType
 
 from eodhp_utils.messagers import CatalogueChangeMessager
@@ -22,14 +22,23 @@ DEBUG_TOPIC = "eodhp-utils-debugging"
 SUSPEND_TIME = 5
 
 # Only set a new provider if one isn't already set.
-current_provider = trace.get_tracer_provider()
-if not isinstance(current_provider, TracerProvider):
-    provider = TracerProvider()
-    provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
-    provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-    trace.set_tracer_provider(provider)
-else:
-    provider = current_provider
+# current_provider = trace.get_tracer_provider()
+# if not isinstance(current_provider, TracerProvider):
+#     provider = TracerProvider()
+#     provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
+#     provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+#     trace.set_tracer_provider(provider)
+# else:
+#     provider = current_provider
+
+# Create and set a new tracer provider
+provider = TracerProvider()
+# Add the BaggageSpanProcessor so that baggage entries are copied as span attributes
+provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
+# Use SimpleSpanProcessor for immediate export to the console
+# provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(provider)
 
 # Acquire tracer for this module
 tracer = trace.get_tracer(__name__)

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -193,9 +193,14 @@ class Runner:
         incoming_properties = msg.properties()
         logging.debug(f"Catalogue change message received from Pulsar : {incoming_properties}")
         ctx = extract(incoming_properties)
-
+        logging.debug(f"ctx from message : {ctx}")
+        baggage = get_all()
+        for key, value in baggage.items():
+            logging.debug(f"baggage in transformer : {key}:{value}")
         # Start a new span using extracted trace context
         with tracer.start_as_current_span(f"process_{topic_name}", context=ctx) as span:
+            logging.debug(f"span in transformer : {span}")
+            logging.debug(f"ctx items in transformer : {ctx.items()}")
             for key, value in ctx.items():
                 span.set_attribute(key, value)
 

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -86,6 +86,12 @@ class AddBaggageToLogFilter(logging.Filter):
 
 def setup_logging(verbosity=0, enable_otel_logging=True):
     """
+    This should be called based on command line arguments. eg:
+
+    @click.option('-v', '--verbose', count=True)
+    def my_cli(verbose):
+        setup_logging(verbosity=verbose)
+
     Configures logging based on verbosity and whether OpenTelemetry logging is enabled.
     When OTEL logging is enabled, baggage is automatically injected into each log record.
     """

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -191,6 +191,7 @@ class Runner:
 
         # Extract OpenTelemetry trace context from Pulsar message
         incoming_properties = msg.properties()
+        logging.debug(f"Catalogue change message received from Pulsar : {incoming_properties}")
         ctx = extract(incoming_properties)
 
         # Start a new span using extracted trace context

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -21,11 +21,17 @@ aws_client = None
 DEBUG_TOPIC = "eodhp-utils-debugging"
 SUSPEND_TIME = 5
 
-# Create and set a new tracer provider
-provider = TracerProvider()
-provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
-provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
-trace.set_tracer_provider(provider)
+# --- Tracer Provider Setup ---
+current_provider = trace.get_tracer_provider()
+if not isinstance(current_provider, TracerProvider):
+    provider = TracerProvider()
+    provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(provider)
+else:
+    provider = current_provider
+    # add baggage processor
+    provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
 
 # Acquire tracer for this module
 tracer = trace.get_tracer(__name__)

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -95,6 +95,7 @@ def setup_logging(verbosity=0, enable_otel_logging=True):
         logging.setLogRecordFactory(custom_record_factory)
 
         # Instrument logging with the custom log hook.
+        # Use set_logging_format=False so that our basicConfig() call isn't overridden.
         LoggingInstrumentor().instrument(set_logging_format=False, log_hook=add_baggage_to_log)
         log_format = OTEL_LOG_FORMAT
     else:

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -9,6 +9,8 @@ import boto3.session
 from opentelemetry import trace
 from opentelemetry.baggage import get_all
 from opentelemetry.propagate import extract
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from pulsar import Client, Consumer, ConsumerDeadLetterPolicy, ConsumerType
 
 from eodhp_utils.messagers import CatalogueChangeMessager
@@ -17,6 +19,11 @@ pulsar_client = None
 aws_client = None
 DEBUG_TOPIC = "eodhp-utils-debugging"
 SUSPEND_TIME = 5
+
+# Set up the tracer provider with a ConsoleSpanExporter
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(provider)
 
 # Acquire tracer for this module
 tracer = trace.get_tracer(__name__)

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -11,7 +11,7 @@ from opentelemetry.baggage import get_all
 from opentelemetry.processor.baggage import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
 from opentelemetry.propagate import extract
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 from pulsar import Client, Consumer, ConsumerDeadLetterPolicy, ConsumerType
 
 from eodhp_utils.messagers import CatalogueChangeMessager
@@ -24,7 +24,7 @@ SUSPEND_TIME = 5
 # Create and set a new tracer provider
 provider = TracerProvider()
 provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
-provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
 trace.set_tracer_provider(provider)
 
 # Acquire tracer for this module

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import boto3.session
 from opentelemetry import trace
+from opentelemetry.baggage import get_all
 from opentelemetry.processor.baggage import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
 from opentelemetry.propagate import extract
 from opentelemetry.sdk.trace import TracerProvider
@@ -169,6 +170,9 @@ class Runner:
         with tracer.start_as_current_span(f"process_{topic_name}", context=ctx) as span:
             for key, value in ctx.items():
                 span.set_attribute(key, value)
+
+            current_baggage = get_all()
+            logging.info(f"Baggage in process_msg: {current_baggage}")
 
             failures = messager.consume(msg)
 

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -11,7 +11,7 @@ from opentelemetry.baggage import get_all
 from opentelemetry.processor.baggage import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
 from opentelemetry.propagate import extract
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from pulsar import Client, Consumer, ConsumerDeadLetterPolicy, ConsumerType
 
 from eodhp_utils.messagers import CatalogueChangeMessager
@@ -21,23 +21,10 @@ aws_client = None
 DEBUG_TOPIC = "eodhp-utils-debugging"
 SUSPEND_TIME = 5
 
-# Only set a new provider if one isn't already set.
-# current_provider = trace.get_tracer_provider()
-# if not isinstance(current_provider, TracerProvider):
-#     provider = TracerProvider()
-#     provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
-#     provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-#     trace.set_tracer_provider(provider)
-# else:
-#     provider = current_provider
-
 # Create and set a new tracer provider
 provider = TracerProvider()
-# Add the BaggageSpanProcessor so that baggage entries are copied as span attributes
 provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
-# Use SimpleSpanProcessor for immediate export to the console
-# provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
 trace.set_tracer_provider(provider)
 
 # Acquire tracer for this module

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -8,10 +8,7 @@ from typing import Optional
 import boto3.session
 from opentelemetry import trace
 from opentelemetry.baggage import get_all
-from opentelemetry.processor.baggage import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
 from opentelemetry.propagate import extract
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from pulsar import Client, Consumer, ConsumerDeadLetterPolicy, ConsumerType
 
 from eodhp_utils.messagers import CatalogueChangeMessager
@@ -20,18 +17,6 @@ pulsar_client = None
 aws_client = None
 DEBUG_TOPIC = "eodhp-utils-debugging"
 SUSPEND_TIME = 5
-
-# Set up OpenTelemetry Tracer Provider
-tracer_provider = TracerProvider()
-
-# Automatically copy ALL baggage entries to span attributes
-tracer_provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
-
-# Optional: Export spans to console for debugging
-tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-
-# Register globally
-trace.set_tracer_provider(tracer_provider)
 
 # Acquire tracer for this module
 tracer = trace.get_tracer(__name__)
@@ -172,7 +157,7 @@ class Runner:
                 span.set_attribute(key, value)
 
             current_baggage = get_all()
-            logging.info(f"Baggage in process_msg: {current_baggage}")
+            logging.info(f"Baggage in process_msg from runner py utils: {current_baggage}")
 
             failures = messager.consume(msg)
 

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -9,8 +9,6 @@ import boto3.session
 from opentelemetry import trace
 from opentelemetry.baggage import get_all
 from opentelemetry.propagate import extract
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from pulsar import Client, Consumer, ConsumerDeadLetterPolicy, ConsumerType
 
 from eodhp_utils.messagers import CatalogueChangeMessager
@@ -19,11 +17,6 @@ pulsar_client = None
 aws_client = None
 DEBUG_TOPIC = "eodhp-utils-debugging"
 SUSPEND_TIME = 5
-
-# Set up the tracer provider with a ConsoleSpanExporter
-provider = TracerProvider()
-provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-trace.set_tracer_provider(provider)
 
 # Acquire tracer for this module
 tracer = trace.get_tracer(__name__)

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -85,7 +85,7 @@ def add_baggage_to_log(span, record):
     record.baggage = str(get_all())
 
 
-def setup_logging(verbosity=0, enable_otel_logging=False):
+def setup_logging(verbosity=0, enable_otel_logging=True):
     """
     Configures logging based on verbosity and whether OpenTelemetry logging is enabled.
     When OTEL logging is enabled, baggage is automatically injected into each log record.

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -67,14 +67,8 @@ DEFAULT_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 OTEL_LOG_FORMAT = (
     "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] "
     "[trace_id=%(otelTraceID)s span_id=%(otelSpanID)s resource.service.name=%(otelServiceName)s "
-    "trace_sampled=%(otelTraceSampled)s %(baggage)s] - %(message)s"
+    "trace_sampled=%(otelTraceSampled)s baggage=%(baggage)s] - %(message)s"
 )
-OTEL_JSON_FORMAT = (
-    "%(asctime)s %(levelname)s %(name)s %(filename)s %(lineno)d "
-    "%(otelTraceID)s %(otelSpanID)s %(otelServiceName)s %(otelTraceSampled)s "
-    "%(workspace)s %(source_url)s %(message)s"
-)
-json_formatter = jsonlogger.JsonFormatter(OTEL_JSON_FORMAT)
 # Define a custom log record factory to ensure every log record has a 'baggage' attribute.
 _old_log_record_factory = logging.getLogRecordFactory()
 
@@ -99,10 +93,9 @@ def setup_logging(verbosity=0, enable_otel_logging=True):
     if enable_otel_logging:
         # Set our custom record factory to ensure every log record has a baggage attribute.
         logging.setLogRecordFactory(custom_record_factory)
-        # Instrument logging with our custom log hook.
         # Use set_logging_format=False to prevent the instrumentor from overriding our configuration.
         LoggingInstrumentor().instrument(set_logging_format=False, log_hook=add_baggage_to_log)
-        log_format = OTEL_JSON_FORMAT
+        log_format = OTEL_LOG_FORMAT
 
         handler = logging.StreamHandler()
         formatter = jsonlogger.JsonFormatter(log_format)

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -199,11 +199,12 @@ class Runner:
             logging.debug(f"baggage in transformer : {key}:{value}")
         # Start a new span using extracted trace context
         with tracer.start_as_current_span(f"process_{topic_name}", context=ctx) as span:
-            logging.debug(f"span in transformer : {span}")
+            logging.debug(f"span before ctx added in transformer : {span}")
             logging.debug(f"ctx items in transformer : {ctx.items()}")
             for key, value in ctx.items():
                 span.set_attribute(key, value)
 
+            logging.debug(f"span after ctx added in transformer : {span}")
             failures = messager.consume(msg)
 
             if failures.any_temporary():

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -69,7 +69,7 @@ OTEL_LOG_FORMAT = (
 )
 
 
-def setup_logging(verbosity=0, enable_otel_logging=False):
+def setup_logging(verbosity=0, enable_otel_logging=True):
     """
     This should be called based on command line arguments. eg:
 

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -66,7 +66,7 @@ DEFAULT_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 OTEL_LOG_FORMAT = (
     "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] "
     "[trace_id=%(otelTraceID)s span_id=%(otelSpanID)s resource.service.name=%(otelServiceName)s "
-    "trace_sampled=%(otelTraceSampled)s baggage=%(baggage)s] - %(message)s"
+    "trace_sampled=%(otelTraceSampled)s %(baggage)s] - %(message)s"
 )
 
 # Define a custom log record factory to ensure every log record has a 'baggage' attribute.
@@ -82,7 +82,7 @@ def custom_record_factory(*args, **kwargs):
 
 # Define a custom log hook that adds baggage from the current context.
 def add_baggage_to_log(span, record):
-    record.baggage = str(get_all())
+    record.baggage = " ".join(f"{k}={v}" for k, v in get_all().items())
 
 
 def setup_logging(verbosity=0, enable_otel_logging=True):

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 import boto3.session
 from opentelemetry import trace
-from opentelemetry.baggage import get_all
 from opentelemetry.processor.baggage import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
 from opentelemetry.propagate import extract
 from opentelemetry.sdk.trace import TracerProvider
@@ -170,9 +169,6 @@ class Runner:
         with tracer.start_as_current_span(f"process_{topic_name}", context=ctx) as span:
             for key, value in ctx.items():
                 span.set_attribute(key, value)
-
-            current_baggage = get_all()
-            logging.info(f"Baggage in process_msg from runner py utils: {current_baggage}")
 
             failures = messager.consume(msg)
 

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -67,7 +67,7 @@ DEFAULT_LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 OTEL_LOG_FORMAT = (
     "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] "
     "[trace_id=%(otelTraceID)s span_id=%(otelSpanID)s resource.service.name=%(otelServiceName)s "
-    "trace_sampled=%(otelTraceSampled)s baggage=%(baggage)s] - %(message)s"
+    "trace_sampled=%(otelTraceSampled)s workspace=%(workspace)s source_url=%(source_url)s] - %(message)s"
 )
 # Define a custom log record factory to ensure every log record has a 'baggage' attribute.
 _old_log_record_factory = logging.getLogRecordFactory()
@@ -82,7 +82,9 @@ def custom_record_factory(*args, **kwargs):
 
 # Define a custom log hook that adds baggage from the current context.
 def add_baggage_to_log(span, record):
-    record.baggage = " ".join(f"{k}={v}" for k, v in get_all().items())
+    baggage = get_all()
+    for key, value in baggage.items():
+        setattr(record, key, value)
 
 
 def setup_logging(verbosity=0, enable_otel_logging=True):

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -69,15 +69,6 @@ OTEL_LOG_FORMAT = (
     "[trace_id=%(otelTraceID)s span_id=%(otelSpanID)s resource.service.name=%(otelServiceName)s "
     "trace_sampled=%(otelTraceSampled)s workspace=%(workspace)s source_url=%(source_url)s] - %(message)s"
 )
-# Define a custom log record factory to ensure every log record has a 'baggage' attribute.
-_old_log_record_factory = logging.getLogRecordFactory()
-
-
-def custom_record_factory(*args, **kwargs):
-    record = _old_log_record_factory(*args, **kwargs)
-    if "baggage" not in record.__dict__:
-        record.baggage = ""  # Default empty baggage
-    return record
 
 
 # Define a custom log hook that adds baggage from the current context.
@@ -93,8 +84,6 @@ def setup_logging(verbosity=0, enable_otel_logging=True):
     When OTEL logging is enabled, baggage is automatically injected into each log record.
     """
     if enable_otel_logging:
-        # Set our custom record factory to ensure every log record has a baggage attribute.
-        logging.setLogRecordFactory(custom_record_factory)
         # Use set_logging_format=False to prevent the instrumentor from overriding our configuration.
         LoggingInstrumentor().instrument(set_logging_format=False, log_hook=add_baggage_to_log)
         log_format = OTEL_LOG_FORMAT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ dependencies = [
     "faker",
     "opentelemetry-api",
     "opentelemetry-sdk",
-    "opentelemetry-processor-baggage"
+    "opentelemetry-processor-baggage",
+    "opentelemetry-instrumentation-logging"
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,8 @@ dependencies = [
     "boto3",
     "pulsar-client",
     "faker",
-    "opentelemetry-api",
-    "opentelemetry-sdk",
+    "opentelemetry-distro",
+    "opentelemetry-processor-baggage"
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ dependencies = [
     "opentelemetry-api",
     "opentelemetry-sdk",
     "opentelemetry-processor-baggage",
-    "opentelemetry-instrumentation-logging"
+    "opentelemetry-instrumentation-logging",
+    "python-json-logger"
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dependencies = [
     "boto3",
     "pulsar-client",
     "faker",
+    "opentelemetry-api",
+    "opentelemetry-sdk",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ dependencies = [
     "boto3",
     "pulsar-client",
     "faker",
-    "opentelemetry-distro",
+    "opentelemetry-api",
+    "opentelemetry-sdk",
     "opentelemetry-processor-baggage"
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,6 +40,10 @@ coverage==7.6.12
     # via eodhp-utils (pyproject.toml)
 cryptography==44.0.2
     # via moto
+deprecated==1.2.18
+    # via
+    #   opentelemetry-api
+    #   opentelemetry-semantic-conventions
 distlib==0.3.9
     # via virtualenv
 execnet==2.1.1
@@ -54,6 +58,8 @@ identify==2.6.8
     # via pre-commit
 idna==3.10
     # via requests
+importlib-metadata==8.5.0
+    # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
 isort==6.0.1
@@ -78,10 +84,27 @@ mypy-extensions==1.0.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
+opentelemetry-api==1.30.0
+    # via
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-distro==0.51b0
+    # via eodhp-utils (pyproject.toml)
+opentelemetry-instrumentation==0.51b0
+    # via opentelemetry-distro
+opentelemetry-sdk==1.30.0
+    # via opentelemetry-distro
+opentelemetry-semantic-conventions==0.51b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
 packaging==24.2
     # via
     #   black
     #   build
+    #   opentelemetry-instrumentation
     #   pytest
     #   validate-pyproject
 pathspec==0.12.1
@@ -146,7 +169,9 @@ six==1.17.0
 trove-classifiers==2025.3.3.18
     # via validate-pyproject
 typing-extensions==4.12.2
-    # via referencing
+    # via
+    #   opentelemetry-sdk
+    #   referencing
 tzdata==2025.1
     # via faker
 urllib3==2.3.0
@@ -164,8 +189,14 @@ werkzeug==3.1.3
     # via moto
 wheel==0.45.1
     # via pip-tools
+wrapt==1.17.2
+    # via
+    #   deprecated
+    #   opentelemetry-instrumentation
 xmltodict==0.14.2
     # via moto
+zipp==3.21.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -87,9 +87,15 @@ nodeenv==1.9.1
 opentelemetry-api==1.30.0
     # via
     #   eodhp-utils (pyproject.toml)
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+opentelemetry-instrumentation==0.51b0
+    # via opentelemetry-instrumentation-logging
+opentelemetry-instrumentation-logging==0.51b0
+    # via eodhp-utils (pyproject.toml)
 opentelemetry-processor-baggage==0.52b0
     # via eodhp-utils (pyproject.toml)
 opentelemetry-sdk==1.30.0
@@ -97,11 +103,14 @@ opentelemetry-sdk==1.30.0
     #   eodhp-utils (pyproject.toml)
     #   opentelemetry-processor-baggage
 opentelemetry-semantic-conventions==0.51b0
-    # via opentelemetry-sdk
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
 packaging==24.2
     # via
     #   black
     #   build
+    #   opentelemetry-instrumentation
     #   pytest
     #   validate-pyproject
 pathspec==0.12.1
@@ -189,6 +198,7 @@ wheel==0.45.1
 wrapt==1.17.2
     # via
     #   deprecated
+    #   opentelemetry-instrumentation
     #   opentelemetry-processor-baggage
 xmltodict==0.14.2
     # via moto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -86,25 +86,17 @@ nodeenv==1.9.1
     # via pre-commit
 opentelemetry-api==1.30.0
     # via
-    #   opentelemetry-distro
-    #   opentelemetry-instrumentation
+    #   eodhp-utils (pyproject.toml)
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-distro==0.51b0
-    # via eodhp-utils (pyproject.toml)
-opentelemetry-instrumentation==0.51b0
-    # via opentelemetry-distro
 opentelemetry-sdk==1.30.0
-    # via opentelemetry-distro
+    # via eodhp-utils (pyproject.toml)
 opentelemetry-semantic-conventions==0.51b0
-    # via
-    #   opentelemetry-instrumentation
-    #   opentelemetry-sdk
+    # via opentelemetry-sdk
 packaging==24.2
     # via
     #   black
     #   build
-    #   opentelemetry-instrumentation
     #   pytest
     #   validate-pyproject
 pathspec==0.12.1
@@ -190,9 +182,7 @@ werkzeug==3.1.3
 wheel==0.45.1
     # via pip-tools
 wrapt==1.17.2
-    # via
-    #   deprecated
-    #   opentelemetry-instrumentation
+    # via deprecated
 xmltodict==0.14.2
     # via moto
 zipp==3.21.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -86,30 +86,22 @@ nodeenv==1.9.1
     # via pre-commit
 opentelemetry-api==1.30.0
     # via
-    #   opentelemetry-distro
-    #   opentelemetry-instrumentation
+    #   eodhp-utils (pyproject.toml)
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-distro==0.51b0
-    # via eodhp-utils (pyproject.toml)
-opentelemetry-instrumentation==0.51b0
-    # via opentelemetry-distro
 opentelemetry-processor-baggage==0.52b0
     # via eodhp-utils (pyproject.toml)
 opentelemetry-sdk==1.30.0
     # via
-    #   opentelemetry-distro
+    #   eodhp-utils (pyproject.toml)
     #   opentelemetry-processor-baggage
 opentelemetry-semantic-conventions==0.51b0
-    # via
-    #   opentelemetry-instrumentation
-    #   opentelemetry-sdk
+    # via opentelemetry-sdk
 packaging==24.2
     # via
     #   black
     #   build
-    #   opentelemetry-instrumentation
     #   pytest
     #   validate-pyproject
 pathspec==0.12.1
@@ -197,7 +189,6 @@ wheel==0.45.1
 wrapt==1.17.2
     # via
     #   deprecated
-    #   opentelemetry-instrumentation
     #   opentelemetry-processor-baggage
 xmltodict==0.14.2
     # via moto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -148,6 +148,8 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   moto
+python-json-logger==3.3.0
+    # via eodhp-utils (pyproject.toml)
 pyyaml==6.0.2
     # via
     #   pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -86,17 +86,30 @@ nodeenv==1.9.1
     # via pre-commit
 opentelemetry-api==1.30.0
     # via
-    #   eodhp-utils (pyproject.toml)
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation
+    #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-sdk==1.30.0
+opentelemetry-distro==0.51b0
     # via eodhp-utils (pyproject.toml)
+opentelemetry-instrumentation==0.51b0
+    # via opentelemetry-distro
+opentelemetry-processor-baggage==0.52b0
+    # via eodhp-utils (pyproject.toml)
+opentelemetry-sdk==1.30.0
+    # via
+    #   opentelemetry-distro
+    #   opentelemetry-processor-baggage
 opentelemetry-semantic-conventions==0.51b0
-    # via opentelemetry-sdk
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
 packaging==24.2
     # via
     #   black
     #   build
+    #   opentelemetry-instrumentation
     #   pytest
     #   validate-pyproject
 pathspec==0.12.1
@@ -182,7 +195,10 @@ werkzeug==3.1.3
 wheel==0.45.1
     # via pip-tools
 wrapt==1.17.2
-    # via deprecated
+    # via
+    #   deprecated
+    #   opentelemetry-instrumentation
+    #   opentelemetry-processor-baggage
 xmltodict==0.14.2
     # via moto
 zipp==3.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,13 +35,27 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 opentelemetry-api==1.30.0
     # via
-    #   eodhp-utils (pyproject.toml)
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation
+    #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-sdk==1.30.0
+opentelemetry-distro==0.51b0
     # via eodhp-utils (pyproject.toml)
+opentelemetry-instrumentation==0.51b0
+    # via opentelemetry-distro
+opentelemetry-processor-baggage==0.52b0
+    # via eodhp-utils (pyproject.toml)
+opentelemetry-sdk==1.30.0
+    # via
+    #   opentelemetry-distro
+    #   opentelemetry-processor-baggage
 opentelemetry-semantic-conventions==0.51b0
-    # via opentelemetry-sdk
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
+packaging==24.2
+    # via opentelemetry-instrumentation
 pulsar-client==3.6.1
     # via eodhp-utils (pyproject.toml)
 python-dateutil==2.9.0.post0
@@ -67,6 +81,9 @@ tzdata==2025.1
 urllib3==2.3.0
     # via botocore
 wrapt==1.17.2
-    # via deprecated
+    # via
+    #   deprecated
+    #   opentelemetry-instrumentation
+    #   opentelemetry-processor-baggage
 zipp==3.21.0
     # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,9 +36,15 @@ jsonschema-specifications==2024.10.1
 opentelemetry-api==1.30.0
     # via
     #   eodhp-utils (pyproject.toml)
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+opentelemetry-instrumentation==0.51b0
+    # via opentelemetry-instrumentation-logging
+opentelemetry-instrumentation-logging==0.51b0
+    # via eodhp-utils (pyproject.toml)
 opentelemetry-processor-baggage==0.52b0
     # via eodhp-utils (pyproject.toml)
 opentelemetry-sdk==1.30.0
@@ -46,7 +52,11 @@ opentelemetry-sdk==1.30.0
     #   eodhp-utils (pyproject.toml)
     #   opentelemetry-processor-baggage
 opentelemetry-semantic-conventions==0.51b0
-    # via opentelemetry-sdk
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
+packaging==24.2
+    # via opentelemetry-instrumentation
 pulsar-client==3.6.1
     # via eodhp-utils (pyproject.toml)
 python-dateutil==2.9.0.post0
@@ -74,6 +84,7 @@ urllib3==2.3.0
 wrapt==1.17.2
     # via
     #   deprecated
+    #   opentelemetry-instrumentation
     #   opentelemetry-processor-baggage
 zipp==3.21.0
     # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,14 @@ botocore==1.37.6
     #   s3transfer
 certifi==2025.1.31
     # via pulsar-client
+deprecated==1.2.18
+    # via
+    #   opentelemetry-api
+    #   opentelemetry-semantic-conventions
 faker==36.1.1
     # via eodhp-utils (pyproject.toml)
+importlib-metadata==8.5.0
+    # via opentelemetry-api
 jmespath==1.0.1
     # via
     #   boto3
@@ -27,6 +33,24 @@ jsonschema==4.23.0
     # via eodhp-utils (pyproject.toml)
 jsonschema-specifications==2024.10.1
     # via jsonschema
+opentelemetry-api==1.30.0
+    # via
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-distro==0.51b0
+    # via eodhp-utils (pyproject.toml)
+opentelemetry-instrumentation==0.51b0
+    # via opentelemetry-distro
+opentelemetry-sdk==1.30.0
+    # via opentelemetry-distro
+opentelemetry-semantic-conventions==0.51b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-sdk
+packaging==24.2
+    # via opentelemetry-instrumentation
 pulsar-client==3.6.1
     # via eodhp-utils (pyproject.toml)
 python-dateutil==2.9.0.post0
@@ -44,8 +68,16 @@ s3transfer==0.11.4
 six==1.17.0
     # via python-dateutil
 typing-extensions==4.12.2
-    # via referencing
+    # via
+    #   opentelemetry-sdk
+    #   referencing
 tzdata==2025.1
     # via faker
 urllib3==2.3.0
     # via botocore
+wrapt==1.17.2
+    # via
+    #   deprecated
+    #   opentelemetry-instrumentation
+zipp==3.21.0
+    # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,22 +35,13 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 opentelemetry-api==1.30.0
     # via
-    #   opentelemetry-distro
-    #   opentelemetry-instrumentation
+    #   eodhp-utils (pyproject.toml)
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-distro==0.51b0
-    # via eodhp-utils (pyproject.toml)
-opentelemetry-instrumentation==0.51b0
-    # via opentelemetry-distro
 opentelemetry-sdk==1.30.0
-    # via opentelemetry-distro
+    # via eodhp-utils (pyproject.toml)
 opentelemetry-semantic-conventions==0.51b0
-    # via
-    #   opentelemetry-instrumentation
-    #   opentelemetry-sdk
-packaging==24.2
-    # via opentelemetry-instrumentation
+    # via opentelemetry-sdk
 pulsar-client==3.6.1
     # via eodhp-utils (pyproject.toml)
 python-dateutil==2.9.0.post0
@@ -76,8 +67,6 @@ tzdata==2025.1
 urllib3==2.3.0
     # via botocore
 wrapt==1.17.2
-    # via
-    #   deprecated
-    #   opentelemetry-instrumentation
+    # via deprecated
 zipp==3.21.0
     # via importlib-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,8 @@ pulsar-client==3.6.1
     # via eodhp-utils (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via botocore
+python-json-logger==3.3.0
+    # via eodhp-utils (pyproject.toml)
 referencing==0.36.2
     # via
     #   jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,27 +35,18 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 opentelemetry-api==1.30.0
     # via
-    #   opentelemetry-distro
-    #   opentelemetry-instrumentation
+    #   eodhp-utils (pyproject.toml)
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-distro==0.51b0
-    # via eodhp-utils (pyproject.toml)
-opentelemetry-instrumentation==0.51b0
-    # via opentelemetry-distro
 opentelemetry-processor-baggage==0.52b0
     # via eodhp-utils (pyproject.toml)
 opentelemetry-sdk==1.30.0
     # via
-    #   opentelemetry-distro
+    #   eodhp-utils (pyproject.toml)
     #   opentelemetry-processor-baggage
 opentelemetry-semantic-conventions==0.51b0
-    # via
-    #   opentelemetry-instrumentation
-    #   opentelemetry-sdk
-packaging==24.2
-    # via opentelemetry-instrumentation
+    # via opentelemetry-sdk
 pulsar-client==3.6.1
     # via eodhp-utils (pyproject.toml)
 python-dateutil==2.9.0.post0
@@ -83,7 +74,6 @@ urllib3==2.3.0
 wrapt==1.17.2
     # via
     #   deprecated
-    #   opentelemetry-instrumentation
     #   opentelemetry-processor-baggage
 zipp==3.21.0
     # via importlib-metadata


### PR DESCRIPTION
Moves trace context injection inside `Messager.consume()` and deserialization inside `Runner._process_messager_msg().`
