### PR TITLE
Support billing collectors better

### DIFF
--- a/eodhp_utils/aws/s3.py
+++ b/eodhp_utils/aws/s3.py
@@ -1,10 +1,11 @@
 import logging
+from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
 
-def upload_file_s3(body: str, bucket: str, key: str, s3_client: boto3.client):
+def upload_file_s3(body: str, bucket: str, key: str, s3_client: boto3.client) -> None:
     """Upload data to an S3 bucket"""
     try:
         s3_client.put_object(Body=body, Bucket=bucket, Key=key)
@@ -12,16 +13,17 @@ def upload_file_s3(body: str, bucket: str, key: str, s3_client: boto3.client):
         logging.error(f"File upload failed: {e}")
 
 
-def get_file_s3(bucket: str, key: str, s3_client: boto3.client) -> str:
+def get_file_s3(bucket: str, key: str, s3_client: boto3.client) -> Optional[str]:
     """Retrieve data from an S3 bucket"""
     try:
         file_obj = s3_client.get_object(Bucket=bucket, Key=key)
         return file_obj["Body"].read().decode("utf-8")
     except ClientError as e:
         logging.error(f"File retrieval failed: {e}")
+        return None
 
 
-def delete_file_s3(bucket: str, key: str, s3_client: boto3.client) -> str:
+def delete_file_s3(bucket: str, key: str, s3_client: boto3.client) -> None:
     """Delete file from an S3 bucket"""
 
     try:

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -248,7 +248,7 @@ class Messager[MSGTYPE, OUTPUTMSGTYPE](ABC):
         def add(self, other):
             return Messager.CatalogueChanges(
                 added=self.added + other.added,
-                updated=self.updated + other.changed,
+                updated=self.updated + other.updated,
                 deleted=self.deleted + other.deleted,
             )
 

--- a/eodhp_utils/pulsar/messages.py
+++ b/eodhp_utils/pulsar/messages.py
@@ -149,7 +149,7 @@ def generate_harvest_schema():
     return generate_schema(properties=properties, required=required)
 
 
-def generate_schema(properties: dict = None, required: list = None) -> dict:
+def generate_schema(properties: dict = None, required: typing.Optional[list] = None) -> dict:
     """Generates a JSON schema with 'type", 'required' and 'properties' fields"""
 
     if properties is None:

--- a/eodhp_utils/pulsar/messages.py
+++ b/eodhp_utils/pulsar/messages.py
@@ -55,16 +55,16 @@ class BillingResourceConsumptionRateSample(Record):
     rate = Double()
 
     @staticmethod
-    def get_fake():
+    def get_fake(sample_time=None, rate=None, workspace=None, sku=None):
         fake = Faker()
 
         crs = BillingResourceConsumptionRateSample()
         crs.uuid = fake.uuid4()
-        crs.sample_time = fake.past_datetime("-1h").isoformat()
-        crs.sku = fake.pystr(4, 10)
+        crs.sample_time = sample_time or fake.past_datetime("-1h").isoformat()
+        crs.sku = sku or fake.pystr(4, 10)
         crs.user = fake.uuid4()
-        crs.workspace = fake.user_name()
-        crs.rate = fake.pyfloat()
+        crs.workspace = workspace or fake.user_name()
+        crs.rate = rate or fake.pyfloat()
 
         return crs
 

--- a/eodhp_utils/pulsar/messages.py
+++ b/eodhp_utils/pulsar/messages.py
@@ -46,6 +46,44 @@ def generate_billingevent_schema() -> Schema:
     return JsonSchema(BillingEvent)
 
 
+class BillingResourceConsumptionRateSample(Record):
+    uuid = String()
+    sample_time = String()  # ISO datetime in UTC
+    sku = String()
+    user = String()  # UUID for the user
+    workspace = String()  # workspace name
+    rate = Double()
+
+    @staticmethod
+    def get_fake():
+        fake = Faker()
+
+        crs = BillingResourceConsumptionRateSample()
+        crs.uuid = fake.uuid4()
+        crs.sample_time = fake.past_datetime("-1h").isoformat()
+        crs.sku = fake.pystr(4, 10)
+        crs.user = fake.uuid4()
+        crs.workspace = fake.user_name()
+        crs.rate = fake.pyfloat()
+
+        return crs
+
+    def __repr__(self):
+        return (
+            "BillingResourceConsumptionRateSample("
+            + f"{self.uuid=}, "
+            + f"{self.sample_time=}, "
+            + f"{self.sku=}, "
+            + f"{self.user=}, "
+            + f"{self.workspace=}, "
+            + f"{self.rate=}))"
+        )
+
+
+def generate_billingresourceconsumptionratesample_schema() -> Schema:
+    return JsonSchema(BillingResourceConsumptionRateSample)
+
+
 class WorkspaceObjectStoreSettings(Record):
     store_id = String()  # UUID
     name = String()

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -84,7 +84,7 @@ class AddBaggageToLogFilter(logging.Filter):
         return True
 
 
-def setup_logging(verbosity=0, enable_otel_logging=True):
+def setup_logging(verbosity=0, enable_otel_logging=None):
     """
     This should be called based on command line arguments. eg:
 
@@ -94,7 +94,16 @@ def setup_logging(verbosity=0, enable_otel_logging=True):
 
     Configures logging based on verbosity and whether OpenTelemetry logging is enabled.
     When OTEL logging is enabled, baggage is automatically injected into each log record.
+
+    By default, otel structured logging is enabled if we're running in Kubernetes or
+    the OTEL_SERVICE_NAME environment variable is set.
     """
+    enable_otel_logging = (
+        enable_otel_logging
+        or "KUBERNETES_SERVICE_HOST" in os.environ
+        or "OTEL_SERVICE_NAME" in os.environ
+    )
+
     if enable_otel_logging:
         # This sets up OTel to add span information to logs.
         LoggingInstrumentor().instrument(set_logging_format=False)

--- a/tests/test_messagers.py
+++ b/tests/test_messagers.py
@@ -1,6 +1,5 @@
 import json
 import sys
-from argparse import Action
 from typing import Sequence
 from unittest.mock import Mock
 
@@ -62,7 +61,7 @@ def test_messages_delivered_to_messager_subclass():
     messages_received = []
 
     class TestMessager(Messager[str, bytes]):
-        def process_msg(self, msg: str) -> Sequence[Action]:
+        def process_msg(self, msg: str) -> Sequence[Messager.Action]:
             messages_received.append(msg)
             return []
 
@@ -79,7 +78,7 @@ def test_messages_delivered_to_messager_subclass():
 
 def test_temporary_or_permanent_failure_from_subclass_recorded_in_result():
     class TestMessager(Messager[str, bytes]):
-        def process_msg(self, msg: str) -> Sequence[Action]:
+        def process_msg(self, msg: str) -> Sequence[Messager.Action]:
             if msg == "temp":
                 raise TemporaryFailure("process_msg")
             elif msg == "perm":
@@ -99,11 +98,11 @@ def test_temporary_or_permanent_failure_from_subclass_recorded_in_result():
 
 def test_s3_upload_action_processed(s3_client):
     class TestMessager(Messager[str, bytes]):
-        def process_msg(self, msg: str) -> Sequence[Action]:
+        def process_msg(self, msg: str) -> Sequence[Messager.Action]:
             return (
-                Messager.S3UploadAction(file_body=b"test_body1", bucket="testbucket2", key="k1"),
-                Messager.S3UploadAction(file_body=b"test_body2", key="k2"),
-                Messager.S3UploadAction(file_body=b"test_body3", mime_type="x-test", key="k3"),
+                Messager.S3UploadAction(file_body="test_body1", bucket="testbucket2", key="k1"),
+                Messager.S3UploadAction(file_body="test_body2", key="k2"),
+                Messager.S3UploadAction(file_body="test_body3", mime_type="x-test", key="k3"),
             )
 
         def gen_empty_catalogue_message(self, msg: str) -> dict:
@@ -127,9 +126,9 @@ def test_s3_upload_action_processed(s3_client):
 
 def test_s3_upload_to_nonexistent_bucket_produces_permanent_error_result(s3_client):
     class TestMessager(Messager[str, bytes]):
-        def process_msg(self, msg: str) -> Sequence[Action]:
+        def process_msg(self, msg: str) -> Sequence[Messager.Action]:
             return (
-                Messager.S3UploadAction(file_body=b"test_body1", bucket="nonexistent", key="k1"),
+                Messager.S3UploadAction(file_body="test_body1", bucket="nonexistent", key="k1"),
             )
 
         def gen_empty_catalogue_message(self, msg: str) -> dict:
@@ -141,9 +140,9 @@ def test_s3_upload_to_nonexistent_bucket_produces_permanent_error_result(s3_clie
 
 def test_s3_timeout_error_produces_temporary_error_result():
     class TestMessager(Messager[str, bytes]):
-        def process_msg(self, msg: str) -> Sequence[Action]:
+        def process_msg(self, msg: str) -> Sequence[Messager.Action]:
             return (
-                Messager.S3UploadAction(file_body=b"test_body1", bucket="nonexistent", key="k1"),
+                Messager.S3UploadAction(file_body="test_body1", bucket="nonexistent", key="k1"),
             )
 
         def gen_empty_catalogue_message(self, msg: str) -> dict:
@@ -158,16 +157,16 @@ def test_s3_timeout_error_produces_temporary_error_result():
 
 def test_output_file_action_catalogue_change_message_sent_and_s3_updated(s3_client):
     class TestMessager(Messager[str, bytes]):
-        def process_msg(self, msg: str) -> Sequence[Action]:
+        def process_msg(self, msg: str) -> Sequence[Messager.Action]:
             return (
                 Messager.OutputFileAction(
-                    file_body=b"test_body1", bucket="testbucket2", cat_path="k1"
+                    file_body="test_body1", bucket="testbucket2", cat_path="k1"
                 ),
-                Messager.OutputFileAction(file_body=b"test_body2", cat_path="k2"),
+                Messager.OutputFileAction(file_body="test_body2", cat_path="k2"),
                 Messager.OutputFileAction(
-                    file_body=b"test_body3", mime_type="x-test", cat_path="k3"
+                    file_body="test_body3", mime_type="x-test", cat_path="k3"
                 ),
-                Messager.OutputFileAction(file_body=b"test_body4", cat_path="k4"),
+                Messager.OutputFileAction(file_body="test_body4", cat_path="k4"),
                 Messager.OutputFileAction(cat_path="k5", file_body=None),
             )
 
@@ -218,8 +217,8 @@ def test_output_file_action_catalogue_change_message_sent_and_s3_updated(s3_clie
 
 def test_output_file_action_treats_invalid_message_json_as_permanent_error(s3_client):
     class TestMessager(Messager[str, bytes]):
-        def process_msg(self, msg: str) -> Sequence[Action]:
-            return (Messager.OutputFileAction(file_body=b"test_body", cat_path="k"),)
+        def process_msg(self, msg: str) -> Sequence[Messager.Action]:
+            return (Messager.OutputFileAction(file_body="test_body", cat_path="k"),)
 
         def gen_empty_catalogue_message(self, msg: str) -> dict:
             return {"id": sys.stderr}
@@ -232,8 +231,8 @@ def test_output_file_action_treats_invalid_message_json_as_permanent_error(s3_cl
 
 def test_output_file_action_treats_pulsar_timeout_as_temporary_error(s3_client):
     class TestMessager(Messager[str, bytes]):
-        def process_msg(self, msg: str) -> Sequence[Action]:
-            return (Messager.OutputFileAction(file_body=b"test_body", cat_path="k"),)
+        def process_msg(self, msg: str) -> Sequence[Messager.Action]:
+            return (Messager.OutputFileAction(file_body="test_body", cat_path="k"),)
 
         def gen_empty_catalogue_message(self, msg: str) -> dict:
             return {"id": "test"}
@@ -252,9 +251,8 @@ def test_catalogue_change_messager_processes_individual_changes(s3_client):
         ) -> Sequence[Messager.Action]:
             return (
                 Messager.OutputFileAction(
-                    file_body=bytes(
-                        f"Updated: {input_bucket=}, {input_key=}, {cat_path=}, {source=}, {target=}",
-                        "utf-8",
+                    file_body=(
+                        f"Updated: {input_bucket=}, {input_key=}, {cat_path=}, {source=}, {target=}"
                     ),
                     cat_path=cat_path,
                 ),
@@ -265,9 +263,8 @@ def test_catalogue_change_messager_processes_individual_changes(s3_client):
         ) -> Sequence[Messager.Action]:
             return (
                 Messager.OutputFileAction(
-                    file_body=bytes(
-                        f"Deleted: {input_bucket=}, {input_key=}, {cat_path=}, {source=}, {target=}",
-                        "utf-8",
+                    file_body=(
+                        f"Deleted: {input_bucket=}, {input_key=}, {cat_path=}, {source=}, {target=}"
                     ),
                     cat_path=cat_path,
                 ),
@@ -412,10 +409,7 @@ def test_stac_change_messager_processes_only_stac(s3_client):
         ) -> Sequence[Messager.Action]:
             return (
                 Messager.OutputFileAction(
-                    file_body=bytes(
-                        f"STAC: {stac.get('id')=}, {cat_path=}, {source=}, {target=}",
-                        "utf-8",
-                    ),
+                    file_body=(f"STAC: {stac.get('id')=}, {cat_path=}, {source=}, {target=}"),
                     cat_path=cat_path,
                 ),
             )
@@ -480,10 +474,10 @@ def test_stac_change_messager_processes_only_stac(s3_client):
     assert actions == [
         Messager.OutputFileAction(
             file_body=(
-                b"STAC: stac.get('id')='sentinel2_ard', "
-                + b"cat_path='path/k4', "
-                + b"source='source-path', "
-                + b"target='target-path'"
+                "STAC: stac.get('id')='sentinel2_ard', "
+                + "cat_path='path/k4', "
+                + "source='source-path', "
+                + "target='target-path'"
             ),
             cat_path="path/k4",
         ),

--- a/tests/test_messagers.py
+++ b/tests/test_messagers.py
@@ -244,6 +244,36 @@ def test_output_file_action_treats_pulsar_timeout_as_temporary_error(s3_client):
     assert testmessager.consume("") == Messager.Failures(permanent=False, temporary=True)
 
 
+def test_adding_changes_to_cataloguechanges_object_results_in_new_object_with_all_changes():
+    changes1 = Messager[bytes, bytes].CatalogueChanges(
+        added=["a", "b"], updated=["c", "d"], deleted=["e", "f"]
+    )
+    changes2 = Messager[bytes, bytes].CatalogueChanges(
+        added=["1", "2"], updated=["3", "4"], deleted=["5", "6"]
+    )
+
+    assert changes1.add(changes2) == Messager[bytes, bytes].CatalogueChanges(
+        added=["a", "b", "1", "2"], updated=["c", "d", "3", "4"], deleted=["e", "f", "5", "6"]
+    )
+
+
+@pytest.mark.parametrize(
+    "added,updated,deleted,expected",
+    [
+        pytest.param([], [], [], False),
+        pytest.param([], [], [], False),
+        pytest.param([], [], [], False),
+        pytest.param([], [], [], False),
+        pytest.param([], [], [], False),
+    ],
+)
+def test_cataloguechanges_evaluates_to_true_only_if_change_is_present(
+    added, updated, deleted, expected
+):
+    changes = Messager[bytes, bytes].CatalogueChanges(added=added, updated=updated, deleted=deleted)
+    assert bool(changes) == expected
+
+
 def test_catalogue_change_messager_processes_individual_changes(s3_client):
     class TestCatalogueChangeMessager(CatalogueChangeMessager):
         def process_update(

--- a/tests/test_messagers.py
+++ b/tests/test_messagers.py
@@ -61,7 +61,7 @@ def pulsar_message_from_dict(val: dict) -> Message:
 def test_messages_delivered_to_messager_subclass():
     messages_received = []
 
-    class TestMessager(Messager[str]):
+    class TestMessager(Messager[str, bytes]):
         def process_msg(self, msg: str) -> Sequence[Action]:
             messages_received.append(msg)
             return []
@@ -78,7 +78,7 @@ def test_messages_delivered_to_messager_subclass():
 
 
 def test_temporary_or_permanent_failure_from_subclass_recorded_in_result():
-    class TestMessager(Messager[str]):
+    class TestMessager(Messager[str, bytes]):
         def process_msg(self, msg: str) -> Sequence[Action]:
             if msg == "temp":
                 raise TemporaryFailure("process_msg")
@@ -98,7 +98,7 @@ def test_temporary_or_permanent_failure_from_subclass_recorded_in_result():
 
 
 def test_s3_upload_action_processed(s3_client):
-    class TestMessager(Messager[str]):
+    class TestMessager(Messager[str, bytes]):
         def process_msg(self, msg: str) -> Sequence[Action]:
             return (
                 Messager.S3UploadAction(file_body=b"test_body1", bucket="testbucket2", key="k1"),
@@ -126,7 +126,7 @@ def test_s3_upload_action_processed(s3_client):
 
 
 def test_s3_upload_to_nonexistent_bucket_produces_permanent_error_result(s3_client):
-    class TestMessager(Messager[str]):
+    class TestMessager(Messager[str, bytes]):
         def process_msg(self, msg: str) -> Sequence[Action]:
             return (
                 Messager.S3UploadAction(file_body=b"test_body1", bucket="nonexistent", key="k1"),
@@ -140,7 +140,7 @@ def test_s3_upload_to_nonexistent_bucket_produces_permanent_error_result(s3_clie
 
 
 def test_s3_timeout_error_produces_temporary_error_result():
-    class TestMessager(Messager[str]):
+    class TestMessager(Messager[str, bytes]):
         def process_msg(self, msg: str) -> Sequence[Action]:
             return (
                 Messager.S3UploadAction(file_body=b"test_body1", bucket="nonexistent", key="k1"),
@@ -157,7 +157,7 @@ def test_s3_timeout_error_produces_temporary_error_result():
 
 
 def test_output_file_action_catalogue_change_message_sent_and_s3_updated(s3_client):
-    class TestMessager(Messager[str]):
+    class TestMessager(Messager[str, bytes]):
         def process_msg(self, msg: str) -> Sequence[Action]:
             return (
                 Messager.OutputFileAction(
@@ -217,7 +217,7 @@ def test_output_file_action_catalogue_change_message_sent_and_s3_updated(s3_clie
 
 
 def test_output_file_action_treats_invalid_message_json_as_permanent_error(s3_client):
-    class TestMessager(Messager[str]):
+    class TestMessager(Messager[str, bytes]):
         def process_msg(self, msg: str) -> Sequence[Action]:
             return (Messager.OutputFileAction(file_body=b"test_body", cat_path="k"),)
 
@@ -231,7 +231,7 @@ def test_output_file_action_treats_invalid_message_json_as_permanent_error(s3_cl
 
 
 def test_output_file_action_treats_pulsar_timeout_as_temporary_error(s3_client):
-    class TestMessager(Messager[str]):
+    class TestMessager(Messager[str, bytes]):
         def process_msg(self, msg: str) -> Sequence[Action]:
             return (Messager.OutputFileAction(file_body=b"test_body", cat_path="k"),)
 
@@ -497,7 +497,7 @@ def fake_billingevent():
 
 def test_pulsarjsonmessager_decodes_billingevent_message_correctly(fake_billingevent):
 
-    class TestJSONMessager(PulsarJSONMessager[BillingEvent]):
+    class TestJSONMessager(PulsarJSONMessager[BillingEvent, bytes]):
         billingevents_received = []
 
         def process_payload(self, be):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -15,7 +15,7 @@ from eodhp_utils import runner
 from eodhp_utils.messagers import Messager
 
 
-class MessagerTester(Messager[str]):
+class MessagerTester(Messager[str, bytes]):
     messages_received = []
 
     def process_msg(self, msg: str) -> Sequence[Action]:
@@ -163,7 +163,7 @@ def test_baggage_propagated_across_call():
     mock_message.properties.return_value = props
     mock_message.topic_name.return_value = "x/test-topic"
 
-    class MessagerBaggageTester(Messager[str]):
+    class MessagerBaggageTester(Messager[str, bytes]):
         def process_msg(self, msg: str) -> Sequence[Action]:
             self.baggage_value = get_baggage("test")
             return []

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,5 @@
 import os
 import time
-from argparse import Action
 from typing import Sequence
 from unittest import mock
 
@@ -16,9 +15,9 @@ from eodhp_utils.messagers import Messager
 
 
 class MessagerTester(Messager[str, bytes]):
-    messages_received = []
+    messages_received: list[str] = []
 
-    def process_msg(self, msg: str) -> Sequence[Action]:
+    def process_msg(self, msg: str) -> Sequence[Messager.Action]:
         self.messages_received.append(msg)
 
         if msg == "EXIT":
@@ -164,7 +163,7 @@ def test_baggage_propagated_across_call():
     mock_message.topic_name.return_value = "x/test-topic"
 
     class MessagerBaggageTester(Messager[str, bytes]):
-        def process_msg(self, msg: str) -> Sequence[Action]:
+        def process_msg(self, msg: str) -> Sequence[Messager.Action]:
             self.baggage_value = get_baggage("test")
             return []
 


### PR DESCRIPTION
This

* Adds support for `PulsarMessageAction`s being returned by Messagers. These result in an arbitrary Pulsar message being sent.
* Adds `BillingResourceConsumptionRateSample` messages which the EFS billing collector needs. These represent a point-in-time sample of the rate at which a resource is being consumed. For example a sample might be 8GB of disk space being consumed so, because we charge for GB-seconds, this represents consumption of 8 gigabyte-seconds per second.
* Corrects a lot of type-related mistakes detected using mypy.
* Changes the logging to only use JSON-format logs in Kubernetes or if OTEL_SERVICE_NAME is set. This makes the output easier to read in dev environments.