### PR TITLE
Functionality to support S3 billing collector

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -16,6 +16,8 @@ jobs:
   pre-commit-preparation:
     name: Pre-commit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
@@ -31,9 +33,13 @@ jobs:
   security-scan:
     name: Call Security Scan
     uses: EO-DataHub/github-actions/.github/workflows/security.yaml@main
+    permissions:
+      contents: read
 
   unit-tests:
     name: Run unit tests
     uses: EO-DataHub/github-actions/.github/workflows/unit-tests-python.yaml@main
+    permissions:
+      contents: read
     with:
       PYTHON_VERSION: "3.12"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,6 +12,8 @@ env:
 jobs:
   unit-testing:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -138,7 +138,7 @@ class Messager[MSGTYPE, OUTPUTMSGTYPE](ABC):
         s3_client=None,
         output_bucket=None,
         cat_output_prefix="",
-        producer: pulsar.Producer = None,
+        producer: Optional[pulsar.Producer] = None,
     ):
         """
         s3_client should be an authenticated boto3 S3 client, such as the result of boto3.client("s3").

--- a/eodhp_utils/messagers.py
+++ b/eodhp_utils/messagers.py
@@ -232,12 +232,16 @@ class Messager[MSGTYPE, OUTPUTMSGTYPE](ABC):
             return self.temporary or self.key_temporary
 
         def add(self, f):
-            return Messager[MSGTYPE].Failures(
+            return Messager[MSGTYPE, OUTPUTMSGTYPE].Failures(
                 key_permanent=self.key_permanent + f.key_permanent,
                 key_temporary=self.key_temporary + f.key_temporary,
                 permanent=self.permanent or f.permanent,
                 temporary=self.temporary or f.temporary,
             )
+
+        @staticmethod
+        def add_two(a, b):
+            return a.add(b)
 
     @dataclasses.dataclass(kw_only=True)
     class CatalogueChanges:

--- a/eodhp_utils/pulsar/messages.py
+++ b/eodhp_utils/pulsar/messages.py
@@ -54,7 +54,7 @@ class BillingResourceConsumptionRateSample(Record):
     rate = Double()
 
     @staticmethod
-    def get_fake(sample_time: str = None, rate=None, workspace=None, sku=None):
+    def get_fake(sample_time: typing.Optional[str] = None, rate=None, workspace=None, sku=None):
         fake = Faker()
 
         crs = BillingResourceConsumptionRateSample()
@@ -186,7 +186,9 @@ def generate_harvest_schema():
     return generate_schema(properties=properties, required=required)
 
 
-def generate_schema(properties: dict = None, required: typing.Optional[list] = None) -> dict:
+def generate_schema(
+    properties: typing.Optional[dict] = None, required: typing.Optional[list] = None
+) -> dict:
     """Generates a JSON schema with 'type", 'required' and 'properties' fields"""
 
     if properties is None:

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -429,7 +429,6 @@ class GeneratorRunner[MSG, MSGOUT]:
     """
 
     messager: Messager[Iterator[MSG], MSGOUT]
-    pulsar_client: Client
     threads: int
     batch_size: int
     name: str
@@ -437,13 +436,11 @@ class GeneratorRunner[MSG, MSGOUT]:
     def __init__(
         self,
         messager: Messager[Iterator[MSG], MSGOUT],
-        pulsar_client: Client,
         threads=0,
         batch_size=1,
         name="generator-runner",
     ):
         self.messager = messager
-        self.pulsar_client = pulsar_client
         self.threads = threads
         self.batch_size = batch_size
         self.name = name

--- a/eodhp_utils/runner.py
+++ b/eodhp_utils/runner.py
@@ -1,9 +1,12 @@
+import itertools
 import json
 import logging
 import os
 import time
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
+from functools import reduce
 from importlib.metadata import PackageNotFoundError, version
-from typing import Optional
+from typing import Iterator, Optional
 
 import boto3.session
 from opentelemetry import trace
@@ -17,7 +20,7 @@ from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProces
 from pulsar import Client, Consumer, ConsumerDeadLetterPolicy, ConsumerType
 from pythonjsonlogger import jsonlogger
 
-from eodhp_utils.messagers import CatalogueChangeMessager
+from eodhp_utils.messagers import CatalogueChangeMessager, Messager
 
 pulsar_client = None
 aws_client = None
@@ -43,7 +46,9 @@ tracer = trace.get_tracer(__name__)
 def get_pulsar_client(pulsar_url=None, message_listener_threads=1):
     global pulsar_client
     if pulsar_client is None:
-        pulsar_url = pulsar_url or os.environ.get("PULSAR_URL")
+        pulsar_url = pulsar_url or os.environ.get(
+            "PULSAR_URL", "pulsar://pulsar-broker.pulsar:6650"
+        )
         pulsar_client = Client(pulsar_url, message_listener_threads=message_listener_threads)
     return pulsar_client
 
@@ -380,3 +385,75 @@ def run(
     )
 
     runner.run()
+
+
+class ImmediateExecutor(Executor):
+    def submit(self, fn, /, *args, **kwargs):
+        f = Future()
+        try:
+            result = fn(*args, **kwargs)
+            f.set_result(result)
+        except Exception as e:
+            f.set_exception(e)
+
+        return f
+
+
+class GeneratorRunner[MSG, MSGOUT]:
+    """
+    A GeneratorRunner is intended for harvesters and other components which generate Pulsar
+    messages based on something pulled from an external source rather than based on incoming
+    messages.
+
+    To use it:
+      - Write a Python generator which generates objects of type MSG. This generator function
+        can pull the data in them from the external source.
+      - Write a Messager which processes these MSG objects as input and returns Actions as
+        usual.
+      - Create a GeneratorRunner[MSG], passing it an instance of the Messager and choosing a
+        number of threads.
+      - Call my_generatorrunner.consume(generator1) as many times as required.
+        This may be once (typical job-based harvester or billing collector) or repeatedly
+        (polling harvester or accounting collector).
+
+    When this is done, the messager will be called with the generator outputs. If threads=0 then
+    the generator and messager will be called only from the calling thread. If threads=1 then
+    the generator will be called from the calling thread and the messager from another,
+    concurrently. If threads>1 then the messager may be called from multiple threads
+    simultaneously but the generator will still only be called from the calling thread.
+
+    The advantages over using a loop are:
+      - Parallel processing of Actions can be handled by the Messagers framework, eg parallel
+        S3 uploads. This may happen even with threads=1.
+      - If threads > 1, multiple threads may be used to process values from a single generator.
+    """
+
+    messager: Messager[Iterator[MSG], MSGOUT]
+    pulsar_client: Client
+    threads: int
+    batch_size: int
+
+    def __init__(
+        self,
+        messager: Messager[Iterator[MSG], MSGOUT],
+        pulsar_client: Client,
+        threads=0,
+        batch_size=1,
+    ):
+        self.messager = messager
+        self.pulsar_client = pulsar_client
+        self.threads = threads
+        self.batch_size = batch_size
+
+    def consume(self, inputs: Iterator[MSG]) -> Messager.Failures:
+        batched_inputs = itertools.batched(inputs, self.batch_size)
+        executor = (
+            ImmediateExecutor()
+            if self.threads == 0
+            else ThreadPoolExecutor(max_workers=self.threads)
+        )
+        with executor as executor:
+            all_failures = executor.map(self.messager.consume, batched_inputs)
+
+        failures = reduce(Messager.Failures.add_two, all_failures, Messager.Failures())
+        return failures

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,17 +4,17 @@
 #
 #    pip-compile --extra=dev --output-file=requirements-dev.txt
 #
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   jsonschema
     #   referencing
 black==25.1.0
     # via eodhp-utils (pyproject.toml)
-boto3==1.37.6
+boto3==1.38.2
     # via
     #   eodhp-utils (pyproject.toml)
     #   moto
-botocore==1.37.6
+botocore==1.38.2
     # via
     #   boto3
     #   eodhp-utils (pyproject.toml)
@@ -36,7 +36,7 @@ click==8.1.8
     # via
     #   black
     #   pip-tools
-coverage==7.6.12
+coverage==7.8.0
     # via eodhp-utils (pyproject.toml)
 cryptography==44.0.2
     # via moto
@@ -48,19 +48,19 @@ distlib==0.3.9
     # via virtualenv
 execnet==2.1.1
     # via pytest-xdist
-faker==36.1.1
+faker==37.1.0
     # via eodhp-utils (pyproject.toml)
 fastjsonschema==2.21.1
     # via validate-pyproject
-filelock==3.17.0
+filelock==3.18.0
     # via virtualenv
-identify==2.6.8
+identify==2.6.10
     # via pre-commit
 idna==3.10
     # via requests
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via opentelemetry-api
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 isort==6.0.1
     # via eodhp-utils (pyproject.toml)
@@ -72,19 +72,19 @@ jmespath==1.0.1
     #   botocore
 jsonschema==4.23.0
     # via eodhp-utils (pyproject.toml)
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
 markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via eodhp-utils (pyproject.toml)
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
-opentelemetry-api==1.30.0
+opentelemetry-api==1.32.1
     # via
     #   eodhp-utils (pyproject.toml)
     #   opentelemetry-instrumentation
@@ -92,21 +92,21 @@ opentelemetry-api==1.30.0
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.51b0
+opentelemetry-instrumentation==0.53b1
     # via opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.51b0
+opentelemetry-instrumentation-logging==0.53b1
     # via eodhp-utils (pyproject.toml)
-opentelemetry-processor-baggage==0.52b0
+opentelemetry-processor-baggage==0.53b1
     # via eodhp-utils (pyproject.toml)
-opentelemetry-sdk==1.30.0
+opentelemetry-sdk==1.32.1
     # via
     #   eodhp-utils (pyproject.toml)
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.51b0
+opentelemetry-semantic-conventions==0.53b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
-packaging==24.2
+packaging==25.0
     # via
     #   black
     #   build
@@ -117,13 +117,13 @@ pathspec==0.12.1
     # via black
 pip-tools==7.4.1
     # via eodhp-utils (pyproject.toml)
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   black
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==4.1.0
+pre-commit==4.2.0
     # via eodhp-utils (pyproject.toml)
 pulsar-client==3.6.1
     # via eodhp-utils (pyproject.toml)
@@ -162,34 +162,34 @@ requests==2.32.3
     # via
     #   moto
     #   responses
-responses==0.25.6
+responses==0.25.7
     # via moto
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.9.9
+ruff==0.11.7
     # via eodhp-utils (pyproject.toml)
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-trove-classifiers==2025.3.3.18
+trove-classifiers==2025.4.11.15
     # via validate-pyproject
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   opentelemetry-sdk
     #   referencing
-tzdata==2025.1
+tzdata==2025.2
     # via faker
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   botocore
     #   requests
     #   responses
-validate-pyproject[all]==0.23
+validate-pyproject[all]==0.24.1
     # via eodhp-utils (pyproject.toml)
-virtualenv==20.29.2
+virtualenv==20.30.0
     # via pre-commit
 watchdog==6.0.0
     # via pytest-watcher

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile
 #
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.37.6
+boto3==1.38.2
     # via eodhp-utils (pyproject.toml)
-botocore==1.37.6
+botocore==1.38.2
     # via
     #   boto3
     #   eodhp-utils (pyproject.toml)
@@ -21,9 +21,9 @@ deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-semantic-conventions
-faker==36.1.1
+faker==37.1.0
     # via eodhp-utils (pyproject.toml)
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via opentelemetry-api
 jmespath==1.0.1
     # via
@@ -31,9 +31,9 @@ jmespath==1.0.1
     #   botocore
 jsonschema==4.23.0
     # via eodhp-utils (pyproject.toml)
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
-opentelemetry-api==1.30.0
+opentelemetry-api==1.32.1
     # via
     #   eodhp-utils (pyproject.toml)
     #   opentelemetry-instrumentation
@@ -41,21 +41,21 @@ opentelemetry-api==1.30.0
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.51b0
+opentelemetry-instrumentation==0.53b1
     # via opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.51b0
+opentelemetry-instrumentation-logging==0.53b1
     # via eodhp-utils (pyproject.toml)
-opentelemetry-processor-baggage==0.52b0
+opentelemetry-processor-baggage==0.53b1
     # via eodhp-utils (pyproject.toml)
-opentelemetry-sdk==1.30.0
+opentelemetry-sdk==1.32.1
     # via
     #   eodhp-utils (pyproject.toml)
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.51b0
+opentelemetry-semantic-conventions==0.53b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
-packaging==24.2
+packaging==25.0
     # via opentelemetry-instrumentation
 pulsar-client==3.6.1
     # via eodhp-utils (pyproject.toml)
@@ -67,21 +67,21 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   opentelemetry-sdk
     #   referencing
-tzdata==2025.1
+tzdata==2025.2
     # via faker
-urllib3==2.3.0
+urllib3==2.4.0
     # via botocore
 wrapt==1.17.2
     # via

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -202,7 +202,7 @@ class IterMessagerTester(Messager[Iterator[str], bytes]):
         self.messages_received.append(msg_list)
         self.thread_ids.add(threading.get_ident())
 
-        # This ensure we need the number of threads the test asks for.
+        # This ensures we need the number of threads the test asks for.
         time.sleep(0.01)
 
         if 666 in msg_list:
@@ -266,9 +266,6 @@ def test_generatorrunner_runs_messager_with_multiple_threads(length, batch_size,
         assert not failures.any_temporary()
 
         expected_threads = min(threads, ceil(length / batch_size))
-        print(
-            f"{len(messager.thread_ids)=}, {length=}, {batch_size=}, {threads=}, {expected_threads=}"
-        )
         assert len(messager.thread_ids) == expected_threads
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -228,9 +228,7 @@ class IterMessagerTester(Messager[Iterator[str], bytes]):
 def test_generatorrunner_runs_messager_with_single_thread(length, batch_size, expected):
     messager = IterMessagerTester()
 
-    gr = eodhp_utils.runner.GeneratorRunner[int, int](
-        messager, mock.MagicMock(name="pulsar-client"), batch_size=batch_size
-    )
+    gr = eodhp_utils.runner.GeneratorRunner[int, int](messager, batch_size=batch_size)
 
     failures = gr.consume(iter(range(length)))
 
@@ -258,7 +256,7 @@ def test_generatorrunner_runs_messager_with_multiple_threads(length, batch_size,
         messager = IterMessagerTester()
 
         gr = eodhp_utils.runner.GeneratorRunner[int, int](
-            messager, mock.MagicMock(name="pulsar-client"), batch_size=batch_size, threads=threads
+            messager, batch_size=batch_size, threads=threads
         )
 
         failures = gr.consume(iter(range(length)))
@@ -278,9 +276,7 @@ def test_generatorrunner_handles_errors():
     for threads in range(1, 10):
         messager = IterMessagerTester()
 
-        gr = eodhp_utils.runner.GeneratorRunner[int, int](
-            messager, mock.MagicMock(name="pulsar-client"), batch_size=4, threads=threads
-        )
+        gr = eodhp_utils.runner.GeneratorRunner[int, int](messager, batch_size=4, threads=threads)
 
         failures = gr.consume([1] * 5 + [666] + [2] * 5)
 


### PR DESCRIPTION
(This is for story 905, not 906 as the branch name suggests)

This:

* Adds the 'GeneratorRunner', conceived of as an equivalent to the runner but for harvesters/collectors. Given a stream of inputs as a generator this will pass them to a Messager, handler concerns such as batching, threading and log context setup.
* Fixes some minor typing errors detected by mypy
* Restrict GitHub action permissions to handle security suggestions from GitHub UI

The GeneratorRunner may later be useful for the STAC and Airbus harvesters.
