### PR TITLE
Set minimum release age to 7 days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ changelog = "https://github.com/EO-DataHub/eodhp-utils/master/CHANGELOG.md"
 
 [tool.uv]
 package = true
+exclude-newer = "7 days"
 
 [build-system]
 requires = ["hatchling", "uv-dynamic-versioning"]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.13.*"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "attrs"
 version = "26.1.0"


### PR DESCRIPTION
Adds `exclude-newer = "7 days"` under `[tool.uv]` so uv's resolver never locks packages published within the last week, matching the org-wide Renovate `minimumReleaseAge` policy (pattern: eodhp-accounting-s3-usage a63872c, ades-fastapi #52).

Context: today's lock-file-maintenance PR #44 pulled in several packages published 1-3 days ago (filelock 3.32.4, moto 5.2.3, boto3 1.43.78, faker 40.37.0), which the 7-day supply-chain policy is meant to prevent. With this merged, #44 can be rebased and will resolve to release-aged versions only.